### PR TITLE
Category, Option 예외 처리 로직 - issue #8

### DIFF
--- a/src/main/java/kr/fiveminutesmarket/category/controller/MainCategoryController.java
+++ b/src/main/java/kr/fiveminutesmarket/category/controller/MainCategoryController.java
@@ -44,4 +44,10 @@ public class MainCategoryController {
         return mainCategoryService.update(id, resource);
     }
 
+    @DeleteMapping("{id}")
+    public ResponseEntity<?> delete(@PathVariable("id") Long id) {
+        mainCategoryService.deleteById(id);
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/src/main/java/kr/fiveminutesmarket/category/error/exception/MainCategoryNameDuplicatedException.java
+++ b/src/main/java/kr/fiveminutesmarket/category/error/exception/MainCategoryNameDuplicatedException.java
@@ -1,0 +1,8 @@
+package kr.fiveminutesmarket.category.error.exception;
+
+public class MainCategoryNameDuplicatedException extends RuntimeException{
+
+    public MainCategoryNameDuplicatedException(String name) {
+        super(name + " MainCategory Duplicated");
+    }
+}

--- a/src/main/java/kr/fiveminutesmarket/category/error/exception/MainCategoryNotFoundException.java
+++ b/src/main/java/kr/fiveminutesmarket/category/error/exception/MainCategoryNotFoundException.java
@@ -1,0 +1,8 @@
+package kr.fiveminutesmarket.category.error.exception;
+
+public class MainCategoryNotFoundException extends RuntimeException{
+
+    public MainCategoryNotFoundException(Long id) {
+        super("#" + id + " MainCategory Not Found");
+    }
+}

--- a/src/main/java/kr/fiveminutesmarket/category/error/exception/ParentCategoryNotExistedException.java
+++ b/src/main/java/kr/fiveminutesmarket/category/error/exception/ParentCategoryNotExistedException.java
@@ -1,0 +1,7 @@
+package kr.fiveminutesmarket.category.error.exception;
+
+public class ParentCategoryNotExistedException extends RuntimeException{
+    public ParentCategoryNotExistedException(Long mainCategoryId) {
+        super("SubCategory's MainCategory #" + mainCategoryId + " Is Not Existed");
+    }
+}

--- a/src/main/java/kr/fiveminutesmarket/category/error/exception/SubCategoryNameDuplicatedException.java
+++ b/src/main/java/kr/fiveminutesmarket/category/error/exception/SubCategoryNameDuplicatedException.java
@@ -1,0 +1,7 @@
+package kr.fiveminutesmarket.category.error.exception;
+
+public class SubCategoryNameDuplicatedException extends RuntimeException{
+    public SubCategoryNameDuplicatedException(String name) {
+        super(name + " SubCategory Duplicated");
+    }
+}

--- a/src/main/java/kr/fiveminutesmarket/category/error/exception/SubCategoryNotFoundException.java
+++ b/src/main/java/kr/fiveminutesmarket/category/error/exception/SubCategoryNotFoundException.java
@@ -1,0 +1,8 @@
+package kr.fiveminutesmarket.category.error.exception;
+
+public class SubCategoryNotFoundException extends RuntimeException{
+
+    public SubCategoryNotFoundException(Long id) {
+        super("#" + id + " SubCategory Not Found");
+    }
+}

--- a/src/main/java/kr/fiveminutesmarket/category/error/handler/MainCategoryExceptionHandler.java
+++ b/src/main/java/kr/fiveminutesmarket/category/error/handler/MainCategoryExceptionHandler.java
@@ -1,0 +1,22 @@
+package kr.fiveminutesmarket.category.error.handler;
+
+import kr.fiveminutesmarket.category.error.exception.MainCategoryNameDuplicatedException;
+import kr.fiveminutesmarket.category.error.exception.MainCategoryNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class MainCategoryExceptionHandler {
+
+    @ExceptionHandler(MainCategoryNotFoundException.class)
+    public ResponseEntity<?> handleNotFoundException(MainCategoryNotFoundException exception) {
+        return new ResponseEntity<>(exception.getMessage(), HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(MainCategoryNameDuplicatedException.class)
+    public ResponseEntity<?> handleNameDuplicatedException(MainCategoryNameDuplicatedException exception) {
+        return new ResponseEntity<>(exception.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/kr/fiveminutesmarket/category/error/handler/SubCategoryExceptionHandler.java
+++ b/src/main/java/kr/fiveminutesmarket/category/error/handler/SubCategoryExceptionHandler.java
@@ -1,0 +1,28 @@
+package kr.fiveminutesmarket.category.error.handler;
+
+import kr.fiveminutesmarket.category.error.exception.ParentCategoryNotExistedException;
+import kr.fiveminutesmarket.category.error.exception.SubCategoryNameDuplicatedException;
+import kr.fiveminutesmarket.category.error.exception.SubCategoryNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class SubCategoryExceptionHandler {
+
+    @ExceptionHandler(SubCategoryNotFoundException.class)
+    public ResponseEntity<?> handleNotFoundException(SubCategoryNotFoundException exception) {
+        return new ResponseEntity<>(exception.getMessage(), HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(SubCategoryNameDuplicatedException.class)
+    public ResponseEntity<?> handleNameDuplicatedException(SubCategoryNameDuplicatedException exception) {
+        return new ResponseEntity<>(exception.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(ParentCategoryNotExistedException.class)
+    public ResponseEntity<?> handleNotExistedParentCategoryException(ParentCategoryNotExistedException exception) {
+        return new ResponseEntity<>(exception.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/kr/fiveminutesmarket/category/repository/MainCategoryRepository.java
+++ b/src/main/java/kr/fiveminutesmarket/category/repository/MainCategoryRepository.java
@@ -15,7 +15,7 @@ public interface MainCategoryRepository {
 
     MainCategory findById(@Param("mainCategoryId") Long mainCategoryId);
 
-    int findByName(@Param("mainCategoryName") String mainCategoryName);
+    int countByName(@Param("mainCategoryName") String mainCategoryName);
 
     int updateMainCategory(@Param("mainCategoryId") Long mainCategoryId,
                            @Param("mainCategory") MainCategory mainCategory);

--- a/src/main/java/kr/fiveminutesmarket/category/repository/MainCategoryRepository.java
+++ b/src/main/java/kr/fiveminutesmarket/category/repository/MainCategoryRepository.java
@@ -15,6 +15,8 @@ public interface MainCategoryRepository {
 
     MainCategory findById(@Param("mainCategoryId") Long mainCategoryId);
 
+    int findByName(@Param("mainCategoryName") String mainCategoryName);
+
     int updateMainCategory(@Param("mainCategoryId") Long mainCategoryId,
                            @Param("mainCategory") MainCategory mainCategory);
 

--- a/src/main/java/kr/fiveminutesmarket/category/repository/SubCategoryRepository.java
+++ b/src/main/java/kr/fiveminutesmarket/category/repository/SubCategoryRepository.java
@@ -15,10 +15,12 @@ public interface SubCategoryRepository {
 
     SubCategory findById(@Param("subCategoryId") Long subCategoryId);
 
-    int findByName(@Param("subCategoryName") String subCategoryName);
+    int countByName(@Param("subCategoryName") String subCategoryName);
 
     int updateSubCategory(@Param("subCategoryId") Long subCategoryId,
                            @Param("subCategory") SubCategory subCategory);
 
     void deleteById(@Param("subCategoryId") Long subCategoryId);
+
+    void deleteByMainCategoryId(@Param("mainCategoryId") Long mainCategoryId);
 }

--- a/src/main/java/kr/fiveminutesmarket/category/repository/SubCategoryRepository.java
+++ b/src/main/java/kr/fiveminutesmarket/category/repository/SubCategoryRepository.java
@@ -15,6 +15,8 @@ public interface SubCategoryRepository {
 
     SubCategory findById(@Param("subCategoryId") Long subCategoryId);
 
+    int findByName(@Param("subCategoryName") String subCategoryName);
+
     int updateSubCategory(@Param("subCategoryId") Long subCategoryId,
                            @Param("subCategory") SubCategory subCategory);
 

--- a/src/main/java/kr/fiveminutesmarket/category/service/MainCategoryService.java
+++ b/src/main/java/kr/fiveminutesmarket/category/service/MainCategoryService.java
@@ -51,5 +51,9 @@ public class MainCategoryService {
 
         return mainCategoryMapper.updateMainCategory(id, mainCategory);
     }
+
+    public void deleteById(Long id) {
+        mainCategoryMapper.deleteById(id);
+    }
     
 }

--- a/src/main/java/kr/fiveminutesmarket/category/service/MainCategoryService.java
+++ b/src/main/java/kr/fiveminutesmarket/category/service/MainCategoryService.java
@@ -3,6 +3,8 @@ package kr.fiveminutesmarket.category.service;
 import kr.fiveminutesmarket.category.domain.MainCategory;
 import kr.fiveminutesmarket.category.dto.request.MainCategoryReqeust;
 import kr.fiveminutesmarket.category.dto.response.MainCategoryResponse;
+import kr.fiveminutesmarket.category.error.exception.MainCategoryNameDuplicatedException;
+import kr.fiveminutesmarket.category.error.exception.MainCategoryNotFoundException;
 import kr.fiveminutesmarket.category.repository.MainCategoryRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,15 +32,21 @@ public class MainCategoryService {
     }
 
     public MainCategoryResponse findById(Long id) {
-
         MainCategory mainCategory = mainCategoryMapper.findById(id);
+
+        if(mainCategory == null)
+            throw new MainCategoryNotFoundException(id);
 
         return mainCategory.toResponse();
     }
 
-    public MainCategoryResponse add(MainCategoryReqeust request) {
+    public MainCategoryResponse add(MainCategoryReqeust resource) {
+        int foundNumber = mainCategoryMapper.findByName(resource.getMainCategoryName());
 
-        MainCategory mainCategory = request.toEntity();
+        if(foundNumber != 0 )
+            throw new MainCategoryNameDuplicatedException(resource.getMainCategoryName());
+
+        MainCategory mainCategory = resource.toEntity();
         mainCategoryMapper.insert(mainCategory);
 
         return mainCategory.toResponse();

--- a/src/main/java/kr/fiveminutesmarket/category/service/MainCategoryService.java
+++ b/src/main/java/kr/fiveminutesmarket/category/service/MainCategoryService.java
@@ -6,6 +6,7 @@ import kr.fiveminutesmarket.category.dto.response.MainCategoryResponse;
 import kr.fiveminutesmarket.category.error.exception.MainCategoryNameDuplicatedException;
 import kr.fiveminutesmarket.category.error.exception.MainCategoryNotFoundException;
 import kr.fiveminutesmarket.category.repository.MainCategoryRepository;
+import kr.fiveminutesmarket.category.repository.SubCategoryRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,15 +17,18 @@ import java.util.stream.Collectors;
 @Transactional
 public class MainCategoryService {
 
-    private final MainCategoryRepository mainCategoryMapper;
+    private final MainCategoryRepository mainCategoryRepository;
 
-    public MainCategoryService(MainCategoryRepository mainCategoryMapper) {
-        this.mainCategoryMapper = mainCategoryMapper;
+    private final SubCategoryRepository subCategoryRepository;
+
+    public MainCategoryService(MainCategoryRepository mainCategoryRepository, SubCategoryRepository subCategoryRepository) {
+        this.mainCategoryRepository = mainCategoryRepository;
+        this.subCategoryRepository = subCategoryRepository;
     }
 
     public List<MainCategoryResponse> findAll() {
 
-        List<MainCategory> mainCategoryList = mainCategoryMapper.findAll();
+        List<MainCategory> mainCategoryList = mainCategoryRepository.findAll();
 
         return mainCategoryList.stream()
                 .map(MainCategory::toResponse)
@@ -32,7 +36,7 @@ public class MainCategoryService {
     }
 
     public MainCategoryResponse findById(Long id) {
-        MainCategory mainCategory = mainCategoryMapper.findById(id);
+        MainCategory mainCategory = mainCategoryRepository.findById(id);
 
         if(mainCategory == null)
             throw new MainCategoryNotFoundException(id);
@@ -41,27 +45,29 @@ public class MainCategoryService {
     }
 
     public MainCategoryResponse add(MainCategoryReqeust resource) {
-        int foundNumber = mainCategoryMapper.findByName(resource.getMainCategoryName());
+        int count = mainCategoryRepository.countByName(resource.getMainCategoryName());
 
-        if(foundNumber != 0 )
+        if(count != 0 )
             throw new MainCategoryNameDuplicatedException(resource.getMainCategoryName());
 
         MainCategory mainCategory = resource.toEntity();
-        mainCategoryMapper.insert(mainCategory);
+        mainCategoryRepository.insert(mainCategory);
 
         return mainCategory.toResponse();
     }
 
     public int update(Long id, MainCategoryReqeust resource) {
 
-        MainCategory mainCategory = mainCategoryMapper.findById(id);
+        MainCategory mainCategory = mainCategoryRepository.findById(id);
         mainCategory.updateInfo(resource);
 
-        return mainCategoryMapper.updateMainCategory(id, mainCategory);
+        return mainCategoryRepository.updateMainCategory(id, mainCategory);
     }
 
     public void deleteById(Long id) {
-        mainCategoryMapper.deleteById(id);
+        subCategoryRepository.deleteByMainCategoryId(id);
+
+        mainCategoryRepository.deleteById(id);
     }
-    
+
 }

--- a/src/main/java/kr/fiveminutesmarket/category/service/SubCategoryService.java
+++ b/src/main/java/kr/fiveminutesmarket/category/service/SubCategoryService.java
@@ -47,9 +47,9 @@ public class SubCategoryService {
     }
 
     public SubCategoryResponse add(SubCategoryReqeust resource) {
-        int foundNumber = subCategoryRepository.findByName(resource.getSubCategoryName());
+        int count = subCategoryRepository.countByName(resource.getSubCategoryName());
 
-        if(foundNumber != 0 )
+        if(count != 0 )
             throw new SubCategoryNameDuplicatedException(resource.getSubCategoryName());
 
         MainCategory mainCategory = mainCategoryRepository.findById(resource.getMainCategoryId());

--- a/src/main/java/kr/fiveminutesmarket/option/controller/ProductOptionController.java
+++ b/src/main/java/kr/fiveminutesmarket/option/controller/ProductOptionController.java
@@ -44,4 +44,10 @@ public class ProductOptionController {
         return productOptionService.update(id, resource);
     }
 
+    @DeleteMapping("{id}")
+    public ResponseEntity<?> delete(@PathVariable("id") Long id) {
+        productOptionService.deleteById(id);
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/src/main/java/kr/fiveminutesmarket/option/error/exception/ParentProductOptionNotExistedException.java
+++ b/src/main/java/kr/fiveminutesmarket/option/error/exception/ParentProductOptionNotExistedException.java
@@ -1,0 +1,7 @@
+package kr.fiveminutesmarket.option.error.exception;
+
+public class ParentProductOptionNotExistedException extends RuntimeException{
+    public ParentProductOptionNotExistedException(Long productOptionId) {
+        super("ProductOptionItem's ProductOption #" + productOptionId + " Is Not Existed");
+    }
+}

--- a/src/main/java/kr/fiveminutesmarket/option/error/exception/ProductOptionItemNameDuplicatedException.java
+++ b/src/main/java/kr/fiveminutesmarket/option/error/exception/ProductOptionItemNameDuplicatedException.java
@@ -1,0 +1,8 @@
+package kr.fiveminutesmarket.option.error.exception;
+
+public class ProductOptionItemNameDuplicatedException extends RuntimeException{
+
+    public ProductOptionItemNameDuplicatedException(String name) {
+        super(name + " ProductOptionItem Duplicated");
+    }
+}

--- a/src/main/java/kr/fiveminutesmarket/option/error/exception/ProductOptionItemNotFoundException.java
+++ b/src/main/java/kr/fiveminutesmarket/option/error/exception/ProductOptionItemNotFoundException.java
@@ -1,0 +1,8 @@
+package kr.fiveminutesmarket.option.error.exception;
+
+public class ProductOptionItemNotFoundException extends RuntimeException{
+
+    public ProductOptionItemNotFoundException(Long id) {
+        super("#" + id + " ProductOptionItem Not Found");
+    }
+}

--- a/src/main/java/kr/fiveminutesmarket/option/error/exception/ProductOptionNotFoundException.java
+++ b/src/main/java/kr/fiveminutesmarket/option/error/exception/ProductOptionNotFoundException.java
@@ -1,0 +1,8 @@
+package kr.fiveminutesmarket.option.error.exception;
+
+public class ProductOptionNotFoundException extends RuntimeException{
+
+    public ProductOptionNotFoundException(Long id) {
+        super("#" + id + " ProductOption Not Found");
+    }
+}

--- a/src/main/java/kr/fiveminutesmarket/option/error/handler/ProductOptionExceptionHandler.java
+++ b/src/main/java/kr/fiveminutesmarket/option/error/handler/ProductOptionExceptionHandler.java
@@ -1,0 +1,17 @@
+package kr.fiveminutesmarket.option.error.handler;
+
+import kr.fiveminutesmarket.option.error.exception.ProductOptionNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ProductOptionExceptionHandler {
+
+    @ExceptionHandler(ProductOptionNotFoundException.class)
+    public ResponseEntity<?> handleNotFoundException(ProductOptionNotFoundException exception) {
+        return new ResponseEntity<>(exception.getMessage(), HttpStatus.NOT_FOUND);
+    }
+
+}

--- a/src/main/java/kr/fiveminutesmarket/option/error/handler/ProductOptionItemExceptionHandler.java
+++ b/src/main/java/kr/fiveminutesmarket/option/error/handler/ProductOptionItemExceptionHandler.java
@@ -1,0 +1,28 @@
+package kr.fiveminutesmarket.option.error.handler;
+
+import kr.fiveminutesmarket.option.error.exception.ParentProductOptionNotExistedException;
+import kr.fiveminutesmarket.option.error.exception.ProductOptionItemNameDuplicatedException;
+import kr.fiveminutesmarket.option.error.exception.ProductOptionItemNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ProductOptionItemExceptionHandler {
+
+    @ExceptionHandler(ProductOptionItemNotFoundException.class)
+    public ResponseEntity<?> handleNotFoundException(ProductOptionItemNotFoundException exception) {
+        return new ResponseEntity<>(exception.getMessage(), HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(ProductOptionItemNameDuplicatedException.class)
+    public ResponseEntity<?> handleNameDuplicatedException(ProductOptionItemNameDuplicatedException exception) {
+        return new ResponseEntity<>(exception.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(ParentProductOptionNotExistedException.class)
+    public ResponseEntity<?> handleNotExistedParentCategoryException(ParentProductOptionNotExistedException exception) {
+        return new ResponseEntity<>(exception.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/kr/fiveminutesmarket/option/repository/ProductOptionItemRepository.java
+++ b/src/main/java/kr/fiveminutesmarket/option/repository/ProductOptionItemRepository.java
@@ -15,6 +15,8 @@ public interface ProductOptionItemRepository {
 
     ProductOptionItem findById(@Param("productOptionItemId") Long productOptionItemId);
 
+    int findByName(@Param("productOptionItemName") String productOptionItemName);
+
     int update(@Param("productOptionItemId") Long productOptionItemId,
                      @Param("productOptionItem") ProductOptionItem productOptionItem);
 

--- a/src/main/java/kr/fiveminutesmarket/option/repository/ProductOptionItemRepository.java
+++ b/src/main/java/kr/fiveminutesmarket/option/repository/ProductOptionItemRepository.java
@@ -15,11 +15,12 @@ public interface ProductOptionItemRepository {
 
     ProductOptionItem findById(@Param("productOptionItemId") Long productOptionItemId);
 
-    int findByName(@Param("productOptionItemName") String productOptionItemName);
+    int countByName(@Param("productOptionItemName") String productOptionItemName);
 
     int update(@Param("productOptionItemId") Long productOptionItemId,
                      @Param("productOptionItem") ProductOptionItem productOptionItem);
 
     void deleteById(@Param("productOptionItemId") Long productOptionItemId);
 
+    void deleteByProductOptionId(@Param("productOptionId") Long productOptionId);
 }

--- a/src/main/java/kr/fiveminutesmarket/option/repository/ProductOptionRepository.java
+++ b/src/main/java/kr/fiveminutesmarket/option/repository/ProductOptionRepository.java
@@ -13,7 +13,7 @@ public interface ProductOptionRepository {
 
     List<ProductOption> findAll();
 
-    ProductOption findByProductOptionId(@Param("productOptionId") Long productOptionId);
+    ProductOption findById(@Param("productOptionId") Long productOptionId);
 
     int updateProductOption(@Param("productOptionId") Long productOptionId,
                             @Param("productOption") ProductOption productOption);

--- a/src/main/java/kr/fiveminutesmarket/option/service/ProductOptionItemService.java
+++ b/src/main/java/kr/fiveminutesmarket/option/service/ProductOptionItemService.java
@@ -46,9 +46,9 @@ public class ProductOptionItemService {
     }
 
     public ProductOptionItemResponse add(ProductOptionItemRequest resource) {
-        int foundNumber = productOptionItemRepository.findByName(resource.getProductOptionItemName());
+        int count = productOptionItemRepository.countByName(resource.getProductOptionItemName());
 
-        if(foundNumber != 0)
+        if(count != 0)
             throw new ProductOptionItemNameDuplicatedException(resource.getProductOptionItemName());
 
         ProductOption productOption = productOptionRepository.findById(resource.getProductOptionId());

--- a/src/main/java/kr/fiveminutesmarket/option/service/ProductOptionService.java
+++ b/src/main/java/kr/fiveminutesmarket/option/service/ProductOptionService.java
@@ -48,4 +48,8 @@ public class ProductOptionService {
         return productOptionMapper.updateProductOption(id, productOption);
     }
 
+    public void deleteById(Long id) {
+        productOptionMapper.deleteById(id);
+    }
+
 }

--- a/src/main/java/kr/fiveminutesmarket/option/service/ProductOptionService.java
+++ b/src/main/java/kr/fiveminutesmarket/option/service/ProductOptionService.java
@@ -3,6 +3,7 @@ package kr.fiveminutesmarket.option.service;
 import kr.fiveminutesmarket.option.domain.ProductOption;
 import kr.fiveminutesmarket.option.dto.request.ProductOptionRequest;
 import kr.fiveminutesmarket.option.dto.response.ProductOptionResponse;
+import kr.fiveminutesmarket.option.error.exception.ProductOptionNotFoundException;
 import kr.fiveminutesmarket.option.repository.ProductOptionRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,7 +29,10 @@ public class ProductOptionService {
     }
 
     public ProductOptionResponse findById(Long id) {
-        ProductOption productOption = productOptionMapper.findByProductOptionId(id);
+        ProductOption productOption = productOptionMapper.findById(id);
+
+        if(productOption == null)
+            throw new ProductOptionNotFoundException(id);
 
         return productOption.toResponse();
     }
@@ -42,7 +46,7 @@ public class ProductOptionService {
 
     public int update(Long id, ProductOptionRequest resource) {
 
-        ProductOption productOption = productOptionMapper.findByProductOptionId(id);
+        ProductOption productOption = productOptionMapper.findById(id);
         productOption.updateInfo(resource);
 
         return productOptionMapper.updateProductOption(id, productOption);

--- a/src/main/java/kr/fiveminutesmarket/option/service/ProductOptionService.java
+++ b/src/main/java/kr/fiveminutesmarket/option/service/ProductOptionService.java
@@ -4,6 +4,7 @@ import kr.fiveminutesmarket.option.domain.ProductOption;
 import kr.fiveminutesmarket.option.dto.request.ProductOptionRequest;
 import kr.fiveminutesmarket.option.dto.response.ProductOptionResponse;
 import kr.fiveminutesmarket.option.error.exception.ProductOptionNotFoundException;
+import kr.fiveminutesmarket.option.repository.ProductOptionItemRepository;
 import kr.fiveminutesmarket.option.repository.ProductOptionRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,21 +16,25 @@ import java.util.stream.Collectors;
 @Transactional
 public class ProductOptionService {
 
-    private final ProductOptionRepository productOptionMapper;
+    private final ProductOptionRepository productOptionRepository;
 
-    public ProductOptionService(ProductOptionRepository optionMapper) {
-        this.productOptionMapper = optionMapper;
+    private final ProductOptionItemRepository productOptionItemRepository;
+
+    public ProductOptionService(ProductOptionRepository productOptionRepository,
+                                ProductOptionItemRepository productOptionItemRepository) {
+        this.productOptionRepository = productOptionRepository;
+        this.productOptionItemRepository = productOptionItemRepository;
     }
 
     public List<ProductOptionResponse> findAll() {
-        List<ProductOption> productOptionList = productOptionMapper.findAll();
+        List<ProductOption> productOptionList = productOptionRepository.findAll();
 
         return productOptionList.stream().map(ProductOption::toResponse)
                 .collect(Collectors.toList());
     }
 
     public ProductOptionResponse findById(Long id) {
-        ProductOption productOption = productOptionMapper.findById(id);
+        ProductOption productOption = productOptionRepository.findById(id);
 
         if(productOption == null)
             throw new ProductOptionNotFoundException(id);
@@ -39,21 +44,23 @@ public class ProductOptionService {
 
     public ProductOptionResponse add(ProductOptionRequest resource) {
         ProductOption productOption = resource.toEntity();
-        productOptionMapper.insert(productOption);
+        productOptionRepository.insert(productOption);
 
         return productOption.toResponse();
     }
 
     public int update(Long id, ProductOptionRequest resource) {
 
-        ProductOption productOption = productOptionMapper.findById(id);
+        ProductOption productOption = productOptionRepository.findById(id);
         productOption.updateInfo(resource);
 
-        return productOptionMapper.updateProductOption(id, productOption);
+        return productOptionRepository.updateProductOption(id, productOption);
     }
 
     public void deleteById(Long id) {
-        productOptionMapper.deleteById(id);
+        productOptionItemRepository.deleteByProductOptionId(id);
+
+        productOptionRepository.deleteById(id);
     }
 
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,6 +4,6 @@ spring:
       on-profile: dev
   datasource:
     driver-class-name: net.sf.log4jdbc.sql.jdbcapi.DriverSpy
-    url: jdbc:log4jdbc:mysql://localhost:3306/fiveminutesmarket?autoreconnect=true&characterEncoding=utf8&serverTimezone=Asia/Seoul&allowMultiQueries=true
+    url: jdbc:log4jdbc:mysql://localhost:3306/fiveminutesmarket?autoreconnect=true&characterEncoding=utf8&serverTimezone=Asia/Seoul
     username: root
     password: springtest

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,6 +4,6 @@ spring:
       on-profile: dev
   datasource:
     driver-class-name: net.sf.log4jdbc.sql.jdbcapi.DriverSpy
-    url: jdbc:log4jdbc:mysql://localhost:3306/fiveminutesmarket?autoreconnect=true&characterEncoding=utf8&serverTimezone=Asia/Seoul
+    url: jdbc:log4jdbc:mysql://localhost:3306/fiveminutesmarket?autoreconnect=true&characterEncoding=utf8&serverTimezone=Asia/Seoul&allowMultiQueries=true
     username: root
     password: springtest

--- a/src/main/resources/mybatis/mapper/MainCategoryMapper.xml
+++ b/src/main/resources/mybatis/mapper/MainCategoryMapper.xml
@@ -30,6 +30,10 @@
     </update>
 
     <delete id="deleteById" parameterType="map">
+        DELETE FROM sub_category
+        WHERE main_category_id = #{mainCategoryId};
 
+        DELETE FROM main_category
+        WHERE main_category_id = #{mainCategoryId};
     </delete>
 </mapper>

--- a/src/main/resources/mybatis/mapper/MainCategoryMapper.xml
+++ b/src/main/resources/mybatis/mapper/MainCategoryMapper.xml
@@ -23,7 +23,7 @@
         WHERE main_category_id = #{mainCategoryId}
     </select>
 
-    <select id="findByName" parameterType="map" resultType="int">
+    <select id="countByName" parameterType="map" resultType="int">
         SELECT COUNT(*)
         FROM main_category
         WHERE main_category_name = #{mainCategoryName}
@@ -36,9 +36,6 @@
     </update>
 
     <delete id="deleteById" parameterType="map">
-        DELETE FROM sub_category
-        WHERE main_category_id = #{mainCategoryId};
-
         DELETE FROM main_category
         WHERE main_category_id = #{mainCategoryId};
     </delete>

--- a/src/main/resources/mybatis/mapper/MainCategoryMapper.xml
+++ b/src/main/resources/mybatis/mapper/MainCategoryMapper.xml
@@ -22,6 +22,12 @@
         FROM main_category
         WHERE main_category_id = #{mainCategoryId}
     </select>
+
+    <select id="findByName" parameterType="map" resultType="int">
+        SELECT COUNT(*)
+        FROM main_category
+        WHERE main_category_name = #{mainCategoryName}
+    </select>
     
     <update id="updateMainCategory" parameterType="map">
         UPDATE main_category

--- a/src/main/resources/mybatis/mapper/ProductOptionItemMapper.xml
+++ b/src/main/resources/mybatis/mapper/ProductOptionItemMapper.xml
@@ -33,7 +33,7 @@
         WHERE product_option_item_id = #{productOptionItemId}
     </select>
 
-    <select id="findByName" parameterType="map" resultType="int">
+    <select id="countByName" parameterType="map" resultType="int">
         SELECT
             COUNT(*)
         FROM product_option_item
@@ -50,5 +50,10 @@
     <delete id="deleteById" parameterType="map">
         DELETE FROM product_option_item
         WHERE product_option_item_id = #{productOptionItemId}
+    </delete>
+
+    <delete id="deleteByProductOptionId" parameterType="map">
+        DELETE FROM product_option_item
+        WHERE product_option_id = #{productOptionId}
     </delete>
 </mapper>

--- a/src/main/resources/mybatis/mapper/ProductOptionItemMapper.xml
+++ b/src/main/resources/mybatis/mapper/ProductOptionItemMapper.xml
@@ -33,6 +33,13 @@
         WHERE product_option_item_id = #{productOptionItemId}
     </select>
 
+    <select id="findByName" parameterType="map" resultType="int">
+        SELECT
+            COUNT(*)
+        FROM product_option_item
+        WHERE product_option_item_name = #{productOptionItemName};
+    </select>
+
     <update id="update" parameterType="map">
         UPDATE product_option_item
         SET product_option_item_name = #{productOptionItem.productOptionItemName},

--- a/src/main/resources/mybatis/mapper/ProductOptionMapper.xml
+++ b/src/main/resources/mybatis/mapper/ProductOptionMapper.xml
@@ -34,6 +34,10 @@
     </update>
 
     <delete id="deleteById" parameterType="map">
+        DELETE FROM product_option_item
+        WHERE product_option_id = #{productOptionId};
 
+        DELETE FROM product_option
+        WHERE product_option_id = #{productOptionId};
     </delete>
 </mapper>

--- a/src/main/resources/mybatis/mapper/ProductOptionMapper.xml
+++ b/src/main/resources/mybatis/mapper/ProductOptionMapper.xml
@@ -34,9 +34,6 @@
     </update>
 
     <delete id="deleteById" parameterType="map">
-        DELETE FROM product_option_item
-        WHERE product_option_id = #{productOptionId};
-
         DELETE FROM product_option
         WHERE product_option_id = #{productOptionId};
     </delete>

--- a/src/main/resources/mybatis/mapper/SubCategoryMapper.xml
+++ b/src/main/resources/mybatis/mapper/SubCategoryMapper.xml
@@ -25,7 +25,7 @@
         WHERE sub_category_id = #{subCategoryId}
     </select>
 
-    <select id="findByName" parameterType="map" resultType="int">
+    <select id="countByName" parameterType="map" resultType="int">
         SELECT
         COUNT(*)
         FROM sub_category
@@ -41,5 +41,10 @@
     <delete id="deleteById" parameterType="map">
         DELETE FROM sub_category
         WHERE sub_category_id = #{subCategoryId}
+    </delete>
+
+    <delete id="deleteByMainCategoryId" parameterType="map">
+        DELETE FROM sub_category
+        WHERE main_category_id = #{mainCategoryId}
     </delete>
 </mapper>

--- a/src/main/resources/mybatis/mapper/SubCategoryMapper.xml
+++ b/src/main/resources/mybatis/mapper/SubCategoryMapper.xml
@@ -25,6 +25,13 @@
         WHERE sub_category_id = #{subCategoryId}
     </select>
 
+    <select id="findByName" parameterType="map" resultType="int">
+        SELECT
+        COUNT(*)
+        FROM sub_category
+        WHERE sub_category_name = #{subCategoryName}
+    </select>
+
     <update id="updateSubCategory" parameterType="map">
         UPDATE sub_category
         SET sub_category_name = #{subCategory.subCategoryName}


### PR DESCRIPTION
- **MainCategory**
    - `MainCategoryNotFoundException`
    조회시 MainCategory 존재X, 주로 select by id에서 발생
    - `MainCategoryNameDuplicatedException`
    새로 입력할 카테고리 이름이 기존에 DB에 등록된 카테고리인 상황
- **SubCategory**
    - `SubCategoryNotFoundException`
    해당 SubCategory가 존재하지 않는 경우
    - `SubCategoryNameDuplicatedException`
    insert 상황에서 DB에 같은 이름의 SubCategory 존재하는 경우
    - `ParentCategoryNotExistedException`
    SubCategory의 상위 category(MainCategory)가 존재하지 않는 경우
- **ProductOption**
    - `ProductOptionNotFoundException`
    해당 ProductOption이 존재하지 않는 경우
- **ProductOptionItem**
    - `ProductOptionItemNotFoundException`
    해당 ProductOptionItem이 존재하지 않는 경우
    - `ProductOptionItemNameDuplicatedException`
    insert 상황에서 DB에 같은 이름의 ProductOptionItem이 존재하는 경우
    - `ParentProductOptionNotExistedException`
    ProductOptionItem 생성시 존재하지 않는 ProductOption id를 insert하려는 경우
  
  
handler 처리에 따른 ErrorResponse에 대한 규격화된 정의가 필요할 것 같습니다.
혹시 Exception 이름에 대해서도 규격화가 필요해보이면 언제든 말씀해주세요!