### PR TITLE
결제 승인에 따른 결제 history 데이터 저장

### DIFF
--- a/src/main/java/kr/fiveminutesmarket/common/utils/RedisUtils.java
+++ b/src/main/java/kr/fiveminutesmarket/common/utils/RedisUtils.java
@@ -1,0 +1,8 @@
+package kr.fiveminutesmarket.common.utils;
+
+public class RedisUtils {
+
+    public static String createKeyWithPrefix(String prefix, String key) {
+        return prefix + ":" + key;
+    }
+}

--- a/src/main/java/kr/fiveminutesmarket/order/controller/OrdersController.java
+++ b/src/main/java/kr/fiveminutesmarket/order/controller/OrdersController.java
@@ -1,22 +1,19 @@
 package kr.fiveminutesmarket.order.controller;
 
 import kr.fiveminutesmarket.common.dto.ResponseDto;
-import kr.fiveminutesmarket.order.domain.KakaoPayReady;
 import kr.fiveminutesmarket.order.dto.OrdersByUserResponseDto;
-import kr.fiveminutesmarket.order.payment.KakaopayPayment;
 import kr.fiveminutesmarket.order.service.OrdersService;
 import kr.fiveminutesmarket.order.service.PaymentService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.net.URISyntaxException;
 import java.util.List;
 
 @RestController
 public class OrdersController {
 
-    private static final Logger logger = LoggerFactory.getLogger(KakaopayPayment.class);
     private final OrdersService ordersService;
     private final PaymentService paymentService;
 
@@ -36,10 +33,18 @@ public class OrdersController {
         return new ResponseDto<>(0, null, ordersByUserResponseDtoList);
     }
 
-    @GetMapping("/orders/{orderId}/{paymentMethod}")
-    public ResponseDto<?> paymentOrder(@PathVariable("orderId") Long orderId,
-                                                   @PathVariable("paymentMethod") String paymentMethod) {
+    @GetMapping("/orders/{orderId}/payments/{paymentMethod}/success")
+    public ResponseDto<String> approvePayment(@PathVariable("orderId") Long orderId,
+                                              @PathVariable("paymentMethod") String paymentMethod,
+                                              @RequestParam("pg_token") String pgToken) {
 
-        return new ResponseDto<>(0, "", paymentService.payment(orderId, paymentMethod));
+        return new ResponseDto<>(0, "결제승인완료", paymentService.approvePayment(orderId, pgToken, paymentMethod));
+    }
+
+    @GetMapping("/orders/{orderId}/{paymentMethod}")
+    public ResponseDto<String> paymentOrder(@PathVariable("orderId") Long orderId,
+                                            @PathVariable("paymentMethod") String paymentMethod) {
+
+        return new ResponseDto<>(0, "결제대기", paymentService.readyPayment(orderId, paymentMethod));
     }
 }

--- a/src/main/java/kr/fiveminutesmarket/order/domain/KakaoPayApproved.java
+++ b/src/main/java/kr/fiveminutesmarket/order/domain/KakaoPayApproved.java
@@ -1,0 +1,96 @@
+package kr.fiveminutesmarket.order.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Date;
+
+public class KakaoPayApproved {
+
+    private String aid;
+
+    private String tid;
+
+    private String cid;
+
+    private String sid;
+
+    @JsonProperty("partner_order_id")
+    private String partnerOrderId;
+
+    @JsonProperty("partner_user_id")
+    private String partnerUserId;
+
+    @JsonProperty("payment_method_type")
+    private String paymentMethodType;
+
+    @JsonProperty("amount")
+    private PayedAmount payedAmount;
+
+    @JsonProperty("item_name")
+    private String itemName;
+
+    @JsonProperty("item_code")
+    private String itemCode;
+
+    private Integer quantity;
+
+    // 결제 준비 요청 시각
+    @JsonProperty("created_at")
+    private Date createdAt;
+
+    // 결제 승인 시각
+    @JsonProperty("approved_at")
+    private Date approvedAt;
+
+    private static class PayedAmount {
+        @JsonProperty("total")
+        private Integer total;
+
+        @JsonProperty("tax_free")
+        private Integer taxFree;
+
+        @JsonProperty("vat")
+        private Integer vat;
+
+        @JsonProperty("point")
+        private Integer point;
+
+        @JsonProperty("discount")
+        private Integer discount;
+    }
+
+    public KakaoPayApproved() {
+    }
+
+    public String getAid() {
+        return aid;
+    }
+
+    public String getTid() {
+        return tid;
+    }
+
+    public String getCid() {
+        return cid;
+    }
+
+    public String getSid() {
+        return sid;
+    }
+
+    public String getPartnerOrderId() {
+        return partnerOrderId;
+    }
+
+    public String getPartnerUserId() {
+        return partnerUserId;
+    }
+
+    public String getPaymentMethodType() {
+        return paymentMethodType;
+    }
+
+    public PayedAmount getPayedAmount() {
+        return payedAmount;
+    }
+}

--- a/src/main/java/kr/fiveminutesmarket/order/domain/KakaoPayReady.java
+++ b/src/main/java/kr/fiveminutesmarket/order/domain/KakaoPayReady.java
@@ -1,14 +1,6 @@
 package kr.fiveminutesmarket.order.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import kr.fiveminutesmarket.common.exception.errors.JsonSerializeFailedException;
-
-import java.time.LocalDateTime;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 public class KakaoPayReady {
 
@@ -61,32 +53,5 @@ public class KakaoPayReady {
 
     public String getCreatedAt() {
         return createdAt;
-    }
-
-    public static KakaoPayReady of(String json) {
-        ObjectMapper mapper = new ObjectMapper();
-
-        if (json == null || !"".equals(json)) {
-            try {
-                return mapper.readValue(json, KakaoPayReady.class);
-            } catch (JsonProcessingException e) {
-                e.printStackTrace();
-            }
-        }
-
-        return null;
-    }
-
-    public static String toJson(KakaoPayReady userSession) {
-        ObjectMapper mapper = new ObjectMapper();
-
-        String json = "";
-        try {
-            json = mapper.writeValueAsString(mapper.convertValue(userSession, KakaoPayReady.class));
-        } catch (JsonProcessingException e) {
-            throw new JsonSerializeFailedException();
-        }
-
-        return json;
     }
 }

--- a/src/main/java/kr/fiveminutesmarket/order/domain/Orders.java
+++ b/src/main/java/kr/fiveminutesmarket/order/domain/Orders.java
@@ -138,4 +138,18 @@ public class Orders {
             throw new OrderStatus.OrderStatusNotPossibleConvertException(from.getStatus(), to.getStatus());
         }
     }
+
+    @Override
+    public String toString() {
+        return "Orders{" +
+                "orderId=" + orderId +
+                ", totalPrice=" + totalPrice +
+                ", address='" + address + '\'' +
+                ", orderStatus=" + orderStatus +
+                ", message='" + message + '\'' +
+                ", createdDate=" + createdDate +
+                ", updatedDate=" + updatedDate +
+                ", userId=" + userId +
+                '}';
+    }
 }

--- a/src/main/java/kr/fiveminutesmarket/order/domain/PaymentHistory.java
+++ b/src/main/java/kr/fiveminutesmarket/order/domain/PaymentHistory.java
@@ -1,0 +1,43 @@
+package kr.fiveminutesmarket.order.domain;
+
+public class PaymentHistory {
+    private Long paymentHistoryId;
+    // 결제 ID
+    private String tid;
+    // 주문 ID
+    private Long ordersId;
+
+    private Boolean success;
+
+    private String paymentLog;
+
+    public PaymentHistory() {
+    }
+
+    public PaymentHistory(String tid, Long ordersId, Boolean success, String paymentLog) {
+        this.tid = tid;
+        this.ordersId = ordersId;
+        this.success = success;
+        this.paymentLog = paymentLog;
+    }
+
+    public Long getPaymentHistoryId() {
+        return paymentHistoryId;
+    }
+
+    public String getTid() {
+        return tid;
+    }
+
+    public Long getOrdersId() {
+        return ordersId;
+    }
+
+    public Boolean isSuccess() {
+        return success;
+    }
+
+    public String getPaymentLog() {
+        return paymentLog;
+    }
+}

--- a/src/main/java/kr/fiveminutesmarket/order/payment/CreditPayment.java
+++ b/src/main/java/kr/fiveminutesmarket/order/payment/CreditPayment.java
@@ -7,7 +7,12 @@ import org.springframework.stereotype.Component;
 public class CreditPayment implements Payment{
 
     @Override
-    public String payment(Orders orderProduct) {
+    public String payment(Orders orders) {
         return "구매 완료!";
+    }
+
+    @Override
+    public String approve(Orders orders, String token) {
+        return "결제 승인 완료!";
     }
 }

--- a/src/main/java/kr/fiveminutesmarket/order/payment/KakaopayPayment.java
+++ b/src/main/java/kr/fiveminutesmarket/order/payment/KakaopayPayment.java
@@ -1,10 +1,13 @@
 package kr.fiveminutesmarket.order.payment;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.fiveminutesmarket.common.exception.errors.JsonSerializeFailedException;
+import kr.fiveminutesmarket.order.domain.KakaoPayApproved;
 import kr.fiveminutesmarket.order.domain.KakaoPayReady;
 import kr.fiveminutesmarket.order.domain.Orders;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -12,17 +15,17 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
-import java.net.URISyntaxException;
+import java.util.concurrent.TimeUnit;
 
 @Component
-public class KakaopayPayment implements Payment{
+public class KakaopayPayment implements Payment {
 
-    private static final Logger logger = LoggerFactory.getLogger(KakaopayPayment.class);
     private static final String HOST = "https://kapi.kakao.com";
-
-    private KakaoPayReady kakaoPayReady;
+    private static final String CID = "TC0ONETIME";
+    public static final String PLATFORM = "kakaopay";
 
     @Value("${kakao.admin.token}")
     private String token;
@@ -30,36 +33,107 @@ public class KakaopayPayment implements Payment{
     @Value("${kakao.redirect_domain}")
     private String domain;
 
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public KakaopayPayment(RedisTemplate<String, Object> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    // 카카오페이 결제 준비
+    @Override
     public String payment(Orders orders) {
-        RestTemplate restTemplate = new RestTemplate();
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", "KakaoAK " + token);
-        headers.add("Accept", MediaType.APPLICATION_JSON_VALUE);
-        headers.add("Content-Type", MediaType.APPLICATION_FORM_URLENCODED_VALUE + ";charset=UTF-8");
-
+        HttpHeaders headers = makeHeaders();
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
 
-        params.add("cid", "TC0ONETIME");
+        // redirect url: [domain]/orders/{orderId}/payments/kakaopay/...
+        String redirectUrl = domain
+                + "/orders/"
+                + orders.getOrderId()
+                + "/payments/"
+                + PLATFORM;
+
+        params.add("cid", CID);
         params.add("partner_order_id", String.valueOf(orders.getOrderId()));
         params.add("partner_user_id", String.valueOf(orders.getUserId()));
         params.add("item_name", orders.getOrderProducts().get(0).getProductName());
         params.add("quantity", String.valueOf(orders.getOrderProducts().get(0).getAmount()));
         params.add("total_amount", String.valueOf(orders.getTotalPrice()));
         params.add("tax_free_amount", String.valueOf(orders.getTotalPrice() / 10));
-        params.add("approval_url", domain + "/orders/payments/kakaopay/success");
-        params.add("cancel_url", domain + "/orders/payments/kakaopay/cancel");
-        params.add("fail_url", domain + "/orders/payments/kakaopay/fail");
+        params.add("approval_url", redirectUrl + "/success");
+        params.add("cancel_url", redirectUrl + "/cancel");
+        params.add("fail_url", redirectUrl + "/fail");
 
+        HttpEntity<MultiValueMap<String, String>> body = new HttpEntity<>(params, headers);
 
-        HttpEntity<MultiValueMap<String, String>> body = new HttpEntity<MultiValueMap<String, String>>(params, headers);
+        URI uri = UriComponentsBuilder
+                .fromUriString(HOST)
+                .path("/v1/payment/ready")
+                .encode()
+                .build()
+                .toUri();
 
-        try {
-            kakaoPayReady = restTemplate.postForObject(new URI(HOST + "/v1/payment/ready"), body, KakaoPayReady.class);
-        } catch (URISyntaxException e) {
-            logger.error(e.getMessage());
+        RestTemplate restTemplate = new RestTemplate();
+        KakaoPayReady kakaoPayReady = restTemplate.postForObject(uri, body, KakaoPayReady.class);
+
+        if (kakaoPayReady != null) {
+            String redisKey = PLATFORM + ":" + orders.getOrderId();
+            redisTemplate.opsForValue().set(redisKey, kakaoPayReady.getTid());
+            redisTemplate.expire(redisKey, 900, TimeUnit.SECONDS);  // 15분 만료시간
         }
 
-        return KakaoPayReady.toJson(kakaoPayReady);
+        return toJson(kakaoPayReady);
+    }
+
+    // 카카오페이 결제 승인
+    @Override
+    public String approve(Orders orders, String token) {
+        HttpHeaders headers = makeHeaders();
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+
+        String redisKey = PLATFORM + ":" + orders.getOrderId();
+        String tid = (String) redisTemplate.opsForValue().get(redisKey);
+
+        params.add("cid", CID);
+        params.add("tid", tid);
+        params.add("partner_order_id", String.valueOf(orders.getOrderId()));
+        params.add("partner_user_id", String.valueOf(orders.getUserId()));
+        params.add("pg_token", token);
+
+        HttpEntity<MultiValueMap<String, String>> body = new HttpEntity<>(params, headers);
+
+        URI uri = UriComponentsBuilder
+                .fromUriString(HOST)
+                .path("/v1/payment/approve")
+                .encode()
+                .build()
+                .toUri();
+
+        RestTemplate restTemplate = new RestTemplate();
+        KakaoPayApproved kakaoPayApproved = restTemplate.postForObject(uri, body, KakaoPayApproved.class);
+
+        return toJson(kakaoPayApproved);
+    }
+
+    // 공통 Header 구성
+    private HttpHeaders makeHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "KakaoAK " + token);
+        headers.add("Accept", MediaType.APPLICATION_JSON_VALUE);
+        headers.add("Content-Type", MediaType.APPLICATION_FORM_URLENCODED_VALUE + ";charset=UTF-8");
+
+        return headers;
+    }
+
+    private String toJson(Object kakaoPayResponse) {
+        ObjectMapper mapper = new ObjectMapper();
+
+        String json = "";
+        try {
+            json = mapper.writeValueAsString(mapper.convertValue(kakaoPayResponse, kakaoPayResponse.getClass()));
+        } catch (JsonProcessingException e) {
+            throw new JsonSerializeFailedException();
+        }
+
+        return json;
     }
 }

--- a/src/main/java/kr/fiveminutesmarket/order/payment/Payment.java
+++ b/src/main/java/kr/fiveminutesmarket/order/payment/Payment.java
@@ -4,5 +4,7 @@ import kr.fiveminutesmarket.order.domain.Orders;
 
 public interface Payment {
 
-    String payment(Orders orderProduct);
+    String payment(Orders orders);
+
+    String approve(Orders orders, String token);
 }

--- a/src/main/java/kr/fiveminutesmarket/order/repository/PaymentHistoryRepository.java
+++ b/src/main/java/kr/fiveminutesmarket/order/repository/PaymentHistoryRepository.java
@@ -1,0 +1,10 @@
+package kr.fiveminutesmarket.order.repository;
+
+import kr.fiveminutesmarket.order.domain.PaymentHistory;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface PaymentHistoryRepository {
+    void insertPaymentHistory(@Param("paymentHistory") PaymentHistory paymentHistory);
+}

--- a/src/main/java/kr/fiveminutesmarket/order/service/PaymentService.java
+++ b/src/main/java/kr/fiveminutesmarket/order/service/PaymentService.java
@@ -1,5 +1,6 @@
 package kr.fiveminutesmarket.order.service;
 
+import kr.fiveminutesmarket.common.utils.RedisUtils;
 import kr.fiveminutesmarket.order.domain.Orders;
 import kr.fiveminutesmarket.order.domain.PaymentHistory;
 import kr.fiveminutesmarket.order.domain.PaymentMethod;
@@ -8,8 +9,6 @@ import kr.fiveminutesmarket.order.payment.KakaopayPayment;
 import kr.fiveminutesmarket.order.payment.Payment;
 import kr.fiveminutesmarket.order.repository.OrdersRepository;
 import kr.fiveminutesmarket.order.repository.PaymentHistoryRepository;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -50,9 +49,11 @@ public class PaymentService {
 
         Orders orders = ordersRepository.findByOrderId(orderId);
 
-        Long ordersId = orders.getOrderId();
-        String tid = (String) redisTemplate.opsForValue().get(KakaopayPayment.PLATFORM + ":" + ordersId);
         String paymentApprovedLog = payment.approve(orders, pgToken);
+
+        Long ordersId = orders.getOrderId();
+        String redisKey = RedisUtils.createKeyWithPrefix(KakaopayPayment.PLATFORM, String.valueOf(orderId));
+        String tid = (String) redisTemplate.opsForValue().get(redisKey);
 
         // 결제 history 생성
         PaymentHistory paymentHistory = toPaymentHistoryEntity(tid, ordersId, true, paymentApprovedLog);

--- a/src/main/java/kr/fiveminutesmarket/order/service/PaymentService.java
+++ b/src/main/java/kr/fiveminutesmarket/order/service/PaymentService.java
@@ -1,32 +1,38 @@
 package kr.fiveminutesmarket.order.service;
 
-import kr.fiveminutesmarket.order.domain.KakaoPayReady;
-import kr.fiveminutesmarket.order.domain.OrderProduct;
 import kr.fiveminutesmarket.order.domain.Orders;
+import kr.fiveminutesmarket.order.domain.PaymentHistory;
 import kr.fiveminutesmarket.order.domain.PaymentMethod;
 import kr.fiveminutesmarket.order.exception.errors.InvalidPaymentMethodException;
 import kr.fiveminutesmarket.order.payment.KakaopayPayment;
 import kr.fiveminutesmarket.order.payment.Payment;
 import kr.fiveminutesmarket.order.repository.OrdersRepository;
+import kr.fiveminutesmarket.order.repository.PaymentHistoryRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
-import java.net.URISyntaxException;
 import java.util.List;
 
 @Service
 public class PaymentService {
-
     private final OrdersRepository ordersRepository;
+    private final PaymentHistoryRepository paymentHistoryRepository;
+    private final RedisTemplate<String, Object> redisTemplate;
     private final List<Payment> payments;
 
-    public PaymentService(OrdersRepository ordersRepository, List<Payment> payments) {
+    public PaymentService(OrdersRepository ordersRepository,
+                          PaymentHistoryRepository paymentHistoryRepository,
+                          RedisTemplate<String, Object> redisTemplate,
+                          List<Payment> payments) {
         this.ordersRepository = ordersRepository;
+        this.paymentHistoryRepository = paymentHistoryRepository;
+        this.redisTemplate = redisTemplate;
         this.payments = payments;
     }
 
-    public String payment(Long orderId, String paymentMethod) {
+    public String readyPayment(Long orderId, String paymentMethod) {
         Payment payment = payments.stream()
                 .filter(clazz -> clazz.getClass() == PaymentMethod.of(paymentMethod).getPayment())
                 .findFirst()
@@ -34,5 +40,28 @@ public class PaymentService {
         Orders orders = ordersRepository.findByOrderId(orderId);
 
         return payment.payment(orders);
+    }
+
+    public String approvePayment(Long orderId, String pgToken, String paymentMethod) {
+        Payment payment = payments.stream()
+                .filter(clazz -> clazz.getClass() == PaymentMethod.of(paymentMethod).getPayment())
+                .findFirst()
+                .orElseThrow(() -> new InvalidPaymentMethodException("잘못된 결제 수단입니다."));
+
+        Orders orders = ordersRepository.findByOrderId(orderId);
+
+        Long ordersId = orders.getOrderId();
+        String tid = (String) redisTemplate.opsForValue().get(KakaopayPayment.PLATFORM + ":" + ordersId);
+        String paymentApprovedLog = payment.approve(orders, pgToken);
+
+        // 결제 history 생성
+        PaymentHistory paymentHistory = toPaymentHistoryEntity(tid, ordersId, true, paymentApprovedLog);
+        paymentHistoryRepository.insertPaymentHistory(paymentHistory);
+        return paymentApprovedLog;
+    }
+
+    public PaymentHistory toPaymentHistoryEntity(String tid, Long ordersId, Boolean success, String paymentLog) {
+
+        return new PaymentHistory(tid, ordersId, success, paymentLog);
     }
 }

--- a/src/main/java/kr/fiveminutesmarket/user/scheduler/MessageRelayScheduler.java
+++ b/src/main/java/kr/fiveminutesmarket/user/scheduler/MessageRelayScheduler.java
@@ -27,8 +27,8 @@ public class MessageRelayScheduler {
      *  - 메일 발송: 발송완료되면 완료된 ResetKeyBox 리스트에 추가
      *  - ResetKeyBox 삭제: 완료된 ResetKeyBox 리스트를 기준으로 ResetKeyBox 테이블 내 데이터 삭제
      */
-    @Scheduled(cron = "*/15 * * * * *")
-    @SchedulerLock(name = "scheduledSendingEmailTask", lockAtLeastFor = "14s", lockAtMostFor = "14s")
+    //@Scheduled(cron = "*/15 * * * * *")
+    //@SchedulerLock(name = "scheduledSendingEmailTask", lockAtLeastFor = "14s", lockAtMostFor = "14s")
     public void schedulingResetPasswordMail() {
         List<ResetKeyBox> resetKeyBoxList = resetKeyBoxRepository.findAll();
         // 리스트 결과값 기준으로 not empty

--- a/src/main/resources/db/migration/V8__create_payment_history_table.sql
+++ b/src/main/resources/db/migration/V8__create_payment_history_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `payment_history` (
+    `payment_history_id` int NOT NULL AUTO_INCREMENT,
+    `tid` varchar(21) NOT NULL,
+    `orders_id` int NOT NULL,
+    `success` tinyint NOT NULL,
+    `payment_log` varchar(1000)  NOT NULL,
+    PRIMARY KEY (`payment_history_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/main/resources/mybatis/mapper/OrdersMapper.xml
+++ b/src/main/resources/mybatis/mapper/OrdersMapper.xml
@@ -58,7 +58,6 @@
             o.order_id AS order_id,
             o.total_price AS total_price,
             o.address AS address,
-            o.payment AS payment,
             o.order_status AS order_status,
             o.message AS message,
             o.created_date AS created_date,

--- a/src/main/resources/mybatis/mapper/PaymentHistoryMapper.xml
+++ b/src/main/resources/mybatis/mapper/PaymentHistoryMapper.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="kr.fiveminutesmarket.order.repository.PaymentHistoryRepository">
+    <insert id="insertPaymentHistory" parameterType="map" useGeneratedKeys="true" keyProperty="paymentHistoryId">
+        INSERT INTO payment_history(tid, orders_id, success, payment_log)
+        VALUES(#{paymentHistory.tid},
+               #{paymentHistory.ordersId},
+               #{paymentHistory.success},
+               #{paymentHistory.paymentLog}
+               )
+    </insert>
+</mapper>

--- a/src/test/java/kr/fiveminutesmarket/order/payment/KakaopayPaymentTest.java
+++ b/src/test/java/kr/fiveminutesmarket/order/payment/KakaopayPaymentTest.java
@@ -1,6 +1,8 @@
 package kr.fiveminutesmarket.order.payment;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.web.client.RestTemplate;
 
 import java.net.URISyntaxException;
 
@@ -8,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class KakaopayPaymentTest {
 
-    KakaopayPayment kakaoPayment = new KakaopayPayment();
+    KakaopayPayment kakaoPayment = new KakaopayPayment(new RedisTemplate<>());
 
     @Test
     void Test() throws URISyntaxException {


### PR DESCRIPTION
### 카카오페이 API 진행
`결제대기` -> `결제요청` -> `결제승인`

### 카카오페이 흐름에 따른 처리
- 결제대기
  - 카카오페이 api response에서 tid값을 redis에 저장(만료시간 15분 설정)
  - 결제 pc url 접속
- 결제요청
  - 카카오페이 pc url에서 결제 진행
  - 결제승인 후 redirect: `GET /orders/1/payments/kakaopay/success`
- 결제승인
  - redis에서 tid 받아옴
  - 카카오페이 결제승인 api를 통해 `KakaoPayApproved` response 생성
  - 해당 객체를 json화해서 payment_history table 저장

생각한 것보다 생각할 것들이 많아서 좀 지체가 됐습니다. 우선 redis와 db 접근에 대해서 다시한번 생각해야될 것 같습니다.
결제취소나 결제실패에 대한 내용은 아직 완성하지 못하여 이번 PR에 이어서 진행하겠습니다.
