### PR TITLE
Category 영역에 대한 JPA Migration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
     // validation

--- a/src/main/java/kr/fiveminutesmarket/category/controller/MainCategoryController.java
+++ b/src/main/java/kr/fiveminutesmarket/category/controller/MainCategoryController.java
@@ -5,12 +5,9 @@ import kr.fiveminutesmarket.category.dto.response.MainCategoryResponse;
 import kr.fiveminutesmarket.category.service.MainCategoryService;
 import kr.fiveminutesmarket.common.dto.ResponseDto;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.List;
 
 @RestController

--- a/src/main/java/kr/fiveminutesmarket/category/controller/SubCategoryController.java
+++ b/src/main/java/kr/fiveminutesmarket/category/controller/SubCategoryController.java
@@ -8,7 +8,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-import java.util.List;
 
 @RestController
 @RequestMapping("/subCategory")
@@ -18,22 +17,6 @@ public class SubCategoryController {
 
     public SubCategoryController(SubCategoryService subCategoryService) {
         this.subCategoryService = subCategoryService;
-    }
-
-    @GetMapping
-    @ResponseStatus(HttpStatus.OK)
-    public ResponseDto<List<SubCategoryResponse>> getAll() {
-        List<SubCategoryResponse> subCategoryList = subCategoryService.findAll();
-
-        return new ResponseDto<>(0,null, subCategoryList);
-    }
-
-    @GetMapping("/{id}")
-    @ResponseStatus(HttpStatus.OK)
-    public ResponseDto<SubCategoryResponse> findById(@PathVariable("id") Long id) {
-        SubCategoryResponse subCategory = subCategoryService.findById(id);
-
-        return new ResponseDto<>(0,null, subCategory);
     }
 
     @PostMapping
@@ -47,10 +30,10 @@ public class SubCategoryController {
     @PutMapping("/{id}")
     @ResponseStatus(HttpStatus.OK)
     public ResponseDto<?> update(@PathVariable("id") Long id,
-                @Valid @RequestBody SubCategoryRequest resource) {
+                                 @Valid @RequestBody SubCategoryRequest resource) {
         subCategoryService.update(id, resource);
 
-        return new ResponseDto<>(0);
+        return new ResponseDto<>(0, "수정 완료하였습니다.");
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/kr/fiveminutesmarket/category/domain/MainCategory.java
+++ b/src/main/java/kr/fiveminutesmarket/category/domain/MainCategory.java
@@ -1,13 +1,20 @@
 package kr.fiveminutesmarket.category.domain;
 
 import kr.fiveminutesmarket.category.dto.request.MainCategoryRequest;
-import kr.fiveminutesmarket.category.dto.response.MainCategoryResponse;
 
+import javax.persistence.*;
+import java.util.List;
+
+@Entity
 public class MainCategory {
-
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long mainCategoryId;
 
     private String mainCategoryName;
+
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE ,mappedBy = "mainCategory")
+    private List<SubCategory> subCategoryList;
 
     public MainCategory() {
     }
@@ -24,15 +31,12 @@ public class MainCategory {
         return mainCategoryName;
     }
 
+    public List<SubCategory> getSubCategoryList() {
+        return subCategoryList;
+    }
+
     public void updateInfo(MainCategoryRequest resource) {
         this.mainCategoryName = resource.getMainCategoryName();
     }
 
-    public MainCategoryResponse toResponse() {
-        MainCategoryResponse response = new MainCategoryResponse();
-        response.setMainCategoryId(mainCategoryId);
-        response.setMainCategoryName(mainCategoryName);
-
-        return response;
-    }
 }

--- a/src/main/java/kr/fiveminutesmarket/category/domain/SubCategory.java
+++ b/src/main/java/kr/fiveminutesmarket/category/domain/SubCategory.java
@@ -1,22 +1,28 @@
 package kr.fiveminutesmarket.category.domain;
 
-import kr.fiveminutesmarket.category.dto.request.SubCategoryRequest;
-import kr.fiveminutesmarket.category.dto.response.SubCategoryResponse;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import javax.persistence.*;
+
+@Entity
 public class SubCategory {
-
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long subCategoryId;
 
     private String subCategoryName;
 
-    private Long mainCategoryId;
+    @ManyToOne
+    @JoinColumn(name = "main_category_id")
+    @JsonIgnore
+    private MainCategory mainCategory;
 
     public SubCategory() {
     }
 
-    public SubCategory(String subCategoryName, Long mainCategoryId) {
+    public SubCategory(String subCategoryName, MainCategory mainCategory) {
         this.subCategoryName = subCategoryName;
-        this.mainCategoryId = mainCategoryId;
+        this.mainCategory = mainCategory;
     }
 
     public Long getSubCategoryId() {
@@ -27,21 +33,12 @@ public class SubCategory {
         return subCategoryName;
     }
 
-    public Long getMainCategoryId() {
-        return mainCategoryId;
+    public MainCategory getMainCategory() {
+        return mainCategory;
     }
 
-    public SubCategoryResponse toResponse() {
-        SubCategoryResponse response = new SubCategoryResponse();
-        response.setSubCategoryId(subCategoryId);
-        response.setSubCategoryName(subCategoryName);
-        response.setMainCategoryId(mainCategoryId);
-
-        return response;
-    }
-
-    public void updateInfo(SubCategoryRequest resource) {
-        this.subCategoryName = resource.getSubCategoryName();
-        this.mainCategoryId = resource.getMainCategoryId();
+    public void updateInfo(String subCategoryName, MainCategory mainCategory) {
+        this.subCategoryName = subCategoryName;
+        this.mainCategory = mainCategory;
     }
 }

--- a/src/main/java/kr/fiveminutesmarket/category/dto/request/MainCategoryRequest.java
+++ b/src/main/java/kr/fiveminutesmarket/category/dto/request/MainCategoryRequest.java
@@ -1,6 +1,5 @@
 package kr.fiveminutesmarket.category.dto.request;
 
-import kr.fiveminutesmarket.category.domain.MainCategory;
 import org.hibernate.validator.constraints.Length;
 
 import javax.validation.constraints.NotBlank;
@@ -22,10 +21,6 @@ public class MainCategoryRequest {
 
     public String getMainCategoryName() {
         return mainCategoryName;
-    }
-
-    public MainCategory toEntity() {
-        return new MainCategory(mainCategoryName);
     }
 
 }

--- a/src/main/java/kr/fiveminutesmarket/category/dto/request/SubCategoryRequest.java
+++ b/src/main/java/kr/fiveminutesmarket/category/dto/request/SubCategoryRequest.java
@@ -1,6 +1,5 @@
 package kr.fiveminutesmarket.category.dto.request;
 
-import kr.fiveminutesmarket.category.domain.SubCategory;
 import org.hibernate.validator.constraints.Length;
 
 import javax.validation.constraints.NotBlank;
@@ -29,9 +28,5 @@ public class SubCategoryRequest {
 
     public Long getMainCategoryId() {
         return mainCategoryId;
-    }
-
-    public SubCategory toEntity() {
-        return new SubCategory(subCategoryName, mainCategoryId);
     }
 }

--- a/src/main/java/kr/fiveminutesmarket/category/dto/response/MainCategoryResponse.java
+++ b/src/main/java/kr/fiveminutesmarket/category/dto/response/MainCategoryResponse.java
@@ -1,24 +1,36 @@
 package kr.fiveminutesmarket.category.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
 public class MainCategoryResponse {
 
     private Long mainCategoryId;
 
     private String mainCategoryName;
 
-    public Long getMainCategoryId() {
-        return mainCategoryId;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private List<SubCategoryResponse> subCategoryResponses;
+
+    public MainCategoryResponse() {
     }
 
-    public void setMainCategoryId(Long mainCategoryId) {
+    public MainCategoryResponse(Long mainCategoryId, String mainCategoryName, List<SubCategoryResponse> subCategoryResponses) {
         this.mainCategoryId = mainCategoryId;
+        this.mainCategoryName = mainCategoryName;
+        this.subCategoryResponses = subCategoryResponses;
+    }
+
+    public Long getMainCategoryId() {
+        return mainCategoryId;
     }
 
     public String getMainCategoryName() {
         return mainCategoryName;
     }
 
-    public void setMainCategoryName(String mainCategoryName) {
-        this.mainCategoryName = mainCategoryName;
+    public List<SubCategoryResponse> getSubCategoryResponses() {
+        return subCategoryResponses;
     }
 }

--- a/src/main/java/kr/fiveminutesmarket/category/dto/response/SubCategoryResponse.java
+++ b/src/main/java/kr/fiveminutesmarket/category/dto/response/SubCategoryResponse.java
@@ -6,30 +6,20 @@ public class SubCategoryResponse {
 
     private String subCategoryName;
 
-    private Long mainCategoryId;
+    public SubCategoryResponse() {
+    }
+
+    public SubCategoryResponse(Long subCategoryId, String subCategoryName) {
+        this.subCategoryId = subCategoryId;
+        this.subCategoryName = subCategoryName;
+    }
 
     public Long getSubCategoryId() {
         return subCategoryId;
     }
 
-    public void setSubCategoryId(Long subCategoryId) {
-        this.subCategoryId = subCategoryId;
-    }
-
     public String getSubCategoryName() {
         return subCategoryName;
-    }
-
-    public void setSubCategoryName(String subCategoryName) {
-        this.subCategoryName = subCategoryName;
-    }
-
-    public Long getMainCategoryId() {
-        return mainCategoryId;
-    }
-
-    public void setMainCategoryId(Long mainCategoryId) {
-        this.mainCategoryId = mainCategoryId;
     }
 
 }

--- a/src/main/java/kr/fiveminutesmarket/category/repository/MainCategoryRepository.java
+++ b/src/main/java/kr/fiveminutesmarket/category/repository/MainCategoryRepository.java
@@ -1,24 +1,9 @@
 package kr.fiveminutesmarket.category.repository;
 
 import kr.fiveminutesmarket.category.domain.MainCategory;
-import org.apache.ibatis.annotations.Mapper;
-import org.apache.ibatis.annotations.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
+public interface MainCategoryRepository extends JpaRepository<MainCategory, Long> {
 
-@Mapper
-public interface MainCategoryRepository {
-
-    int insert(@Param("mainCategory") MainCategory mainCategory);
-
-    List<MainCategory> findAll();
-
-    MainCategory findById(@Param("mainCategoryId") Long mainCategoryId);
-
-    int countByName(@Param("mainCategoryName") String mainCategoryName);
-
-    int updateMainCategory(@Param("mainCategoryId") Long mainCategoryId,
-                           @Param("mainCategory") MainCategory mainCategory);
-
-    void deleteById(@Param("mainCategoryId") Long mainCategoryId);
+    long countByMainCategoryName(String mainCategoryName);
 }

--- a/src/main/java/kr/fiveminutesmarket/category/repository/SubCategoryRepository.java
+++ b/src/main/java/kr/fiveminutesmarket/category/repository/SubCategoryRepository.java
@@ -1,26 +1,9 @@
 package kr.fiveminutesmarket.category.repository;
 
 import kr.fiveminutesmarket.category.domain.SubCategory;
-import org.apache.ibatis.annotations.Mapper;
-import org.apache.ibatis.annotations.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
+public interface SubCategoryRepository extends JpaRepository<SubCategory, Long> {
 
-@Mapper
-public interface SubCategoryRepository {
-
-    int insert(@Param("subCategory") SubCategory subCategory);
-
-    List<SubCategory> findAll();
-
-    SubCategory findById(@Param("subCategoryId") Long subCategoryId);
-
-    int countByName(@Param("subCategoryName") String subCategoryName);
-
-    int updateSubCategory(@Param("subCategoryId") Long subCategoryId,
-                           @Param("subCategory") SubCategory subCategory);
-
-    void deleteById(@Param("subCategoryId") Long subCategoryId);
-
-    void deleteByMainCategoryId(@Param("mainCategoryId") Long mainCategoryId);
+    long countBySubCategoryName(String subCategoryName);
 }

--- a/src/main/java/kr/fiveminutesmarket/category/service/MainCategoryService.java
+++ b/src/main/java/kr/fiveminutesmarket/category/service/MainCategoryService.java
@@ -1,17 +1,20 @@
 package kr.fiveminutesmarket.category.service;
 
 import kr.fiveminutesmarket.category.domain.MainCategory;
+import kr.fiveminutesmarket.category.domain.SubCategory;
 import kr.fiveminutesmarket.category.dto.request.MainCategoryRequest;
 import kr.fiveminutesmarket.category.dto.response.MainCategoryResponse;
 import kr.fiveminutesmarket.category.error.exception.MainCategoryNameDuplicatedException;
 import kr.fiveminutesmarket.category.error.exception.MainCategoryNotFoundException;
 import kr.fiveminutesmarket.category.repository.MainCategoryRepository;
-import kr.fiveminutesmarket.category.repository.SubCategoryRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @Transactional
@@ -19,11 +22,8 @@ public class MainCategoryService {
 
     private final MainCategoryRepository mainCategoryRepository;
 
-    private final SubCategoryRepository subCategoryRepository;
-
-    public MainCategoryService(MainCategoryRepository mainCategoryRepository, SubCategoryRepository subCategoryRepository) {
+    public MainCategoryService(MainCategoryRepository mainCategoryRepository) {
         this.mainCategoryRepository = mainCategoryRepository;
-        this.subCategoryRepository = subCategoryRepository;
     }
 
     public List<MainCategoryResponse> findAll() {
@@ -31,43 +31,54 @@ public class MainCategoryService {
         List<MainCategory> mainCategoryList = mainCategoryRepository.findAll();
 
         return mainCategoryList.stream()
-                .map(MainCategory::toResponse)
+                .map(this::toResponse)
                 .collect(Collectors.toList());
     }
 
     public MainCategoryResponse findById(Long id) {
-        MainCategory mainCategory = mainCategoryRepository.findById(id);
+        MainCategory mainCategory = mainCategoryRepository.findById(id)
+                .orElseThrow(() -> new MainCategoryNotFoundException(id));
 
-        if(mainCategory == null)
-            throw new MainCategoryNotFoundException(id);
-
-        return mainCategory.toResponse();
+        return toResponse(mainCategory);
     }
 
     public MainCategoryResponse add(MainCategoryRequest resource) {
-        int count = mainCategoryRepository.countByName(resource.getMainCategoryName());
+        long count = mainCategoryRepository.countByMainCategoryName(resource.getMainCategoryName());
 
         if(count != 0 )
             throw new MainCategoryNameDuplicatedException(resource.getMainCategoryName());
 
-        MainCategory mainCategory = resource.toEntity();
-        mainCategoryRepository.insert(mainCategory);
+        MainCategory mainCategory = toEntity(resource);
+        MainCategory saved = mainCategoryRepository.save(mainCategory);
 
-        return mainCategory.toResponse();
+        return toResponse(saved);
     }
 
-    public int update(Long id, MainCategoryRequest resource) {
+    public void update(Long id, MainCategoryRequest resource) {
+        MainCategory mainCategory = mainCategoryRepository.findById(id)
+                .orElseThrow(() -> new MainCategoryNotFoundException(id));
 
-        MainCategory mainCategory = mainCategoryRepository.findById(id);
         mainCategory.updateInfo(resource);
-
-        return mainCategoryRepository.updateMainCategory(id, mainCategory);
     }
 
     public void deleteById(Long id) {
-        subCategoryRepository.deleteByMainCategoryId(id);
-
         mainCategoryRepository.deleteById(id);
+    }
+
+    public MainCategory toEntity(MainCategoryRequest resource) {
+        return new MainCategory(resource.getMainCategoryName());
+    }
+
+    public MainCategoryResponse toResponse(MainCategory mainCategory) {
+        Stream<SubCategory> subCategoryStream = Optional.ofNullable(mainCategory.getSubCategoryList())
+                .stream()
+                .flatMap(Collection::stream);
+
+        return new MainCategoryResponse(mainCategory.getMainCategoryId(),
+                mainCategory.getMainCategoryName(),
+                subCategoryStream
+                        .map(SubCategoryService::toResponse)
+                        .collect(Collectors.toList()));
     }
 
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,6 +1,10 @@
 spring:
   datasource:
     driver-class-name: net.sf.log4jdbc.sql.jdbcapi.DriverSpy
+  jpa:
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL5InnoDBDialect
   flyway:
     baseline-on-migrate: true
     baseline-version: 0


### PR DESCRIPTION
### 연관관계 설정
- Main: Sub = 1:N
  - `@ManyToOne`, `@OneToMany` 선언 방식만으로 연관관계 설정가능
  - fetch 전약에 따라 지연로딩 기능 적용 가능
 
### MainCategory delete 기능 적용

- 기존 방식
   - MainCategory와 연관된 SubCategory 내용을 먼저 삭제하고 MainCategory 삭제하는 mapper 메서드를 적용
```java
subCategoryRepository.deleteByMainCategoryId(id);
mainCategoryRepository.deleteById(id);
```
- JPA
  - 영속성 전이 삭제 기능을 사용함으로써 Entity 영역에 선언만해도 delete시 관련 데이터 전부 삭제처리해주는 장점이 있습니다.
  - 만약 `CascadeType.REMOVE` 해당 부분을 속성으로 지정하지 않으면 부모 엔티티만 삭제되는데 여기서 연관된 SubCategory 데이터가 있으면 예외가 발생할 수 있습니다.
```java
// MainCategory.java
@OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE ,mappedBy = "mainCategory")
private List<SubCategory> subCategoryList;
```

### 성능 상의 이슈
- 이부분은 elastic APM으로 MyBatis 사용했을 때와 JPA 적용해서 사용했을 때 어떤 차이가 있는지 확인하고 업데이트 하겠습니다.
